### PR TITLE
Fix note frequencies in desktop player

### DIFF
--- a/player-desktop/mmml-engine.c
+++ b/player-desktop/mmml-engine.c
@@ -21,7 +21,7 @@ void generate_mmml(uint8_t *input_buffer, int32_t total_samples, char *mmml_sour
 		// the rest command is technically note 0 and thus requires a frequency 
 		255,
 		// one octave of notes, equal temperament
-		1024,967,912,861,813,767,724,683,645,609,575,542
+		1644,1551,1464,1382,1305,1231,1162,1097,1035,977,922,871
 	};
 
 	// location of individual samples in sample array


### PR DESCRIPTION
When I converted some music to μMML and then converted it to a WAV file with the desktop player, I found that the notes are too high in frequency. A D5 in the song played at about 943 Hz but should be about 587 Hz. Turned out the `note` array had the wrong values for the sample rate the player runs at (215 kHz). For example, A1 is 55 Hz, so the note value should be 215000/4/55 ≈ 977 (the divide by 4 is because the player interleaves 4 voices), but the value in the `note` array is 609.

The other option is to change the sample rate to 134 kHz, and then the note value would be correct (but that would also affect the tempo).

I have not tested the AVR player, so I don't know if it has the same issue (and it doesn't have an explicitly specified sample rate). If it effectively runs at a 134 kHz sample rate then the frequencies are correct.